### PR TITLE
Update Dataset_metadata_2.0_example

### DIFF
--- a/examples/Dataset_metadata_2.0_example
+++ b/examples/Dataset_metadata_2.0_example
@@ -346,7 +346,7 @@ If the version of the encoding is unknown or if the encoding is not versioned, t
             <gmx:Anchor xlink:href="https://www.iana.org/assignments/media-types/application/gml+xml">gml+xml</gmx:Anchor>
           </gmd:name>
           <gmd:version>
-            <gco:CharacterString>3.2</gco:CharacterString>
+            <gco:CharacterString>3.2.1</gco:CharacterString>
           </gmd:version>
         </gmd:MD_Format>
       </gmd:distributionFormat>

--- a/examples/Dataset_metadata_2.0_example
+++ b/examples/Dataset_metadata_2.0_example
@@ -343,14 +343,11 @@ If the version of the encoding is unknown or if the encoding is not versioned, t
       <gmd:distributionFormat>
         <gmd:MD_Format>
           <gmd:name>
-            <gco:CharacterString>Existing Land Use GML application schema</gco:CharacterString>
+            <gmx:Anchor xlink:href="https://www.iana.org/assignments/media-types/application/gml+xml">gml+xml</gmx:Anchor>
           </gmd:name>
           <gmd:version>
-            <gco:CharacterString>3.0</gco:CharacterString>
+            <gco:CharacterString>3.2</gco:CharacterString>
           </gmd:version>
-          <gmd:specification>
-            <gco:CharacterString>D2.8.III.4 Data Specification on Land Use – Technical Guidelines</gco:CharacterString>
-          </gmd:specification>
         </gmd:MD_Format>
       </gmd:distributionFormat>
       


### PR DESCRIPTION
Data encoding metadata updated to better make them compliant to the TG Requirement 2.6 (only the metadata elements MD_Format.name and MD_Format.version are required) and to make them proper and in line with the meaning given in ISO 19115.  
See also comment https://github.com/inspire-eu-validation/community/issues/53#issuecomment-498410457