### PR TITLE
 Update Dataset_metadata_2.0_example

### DIFF
--- a/examples/Dataset_metadata_2.0_example
+++ b/examples/Dataset_metadata_2.0_example
@@ -123,7 +123,9 @@ The multiplicity of this element is 1..*.-->
           <gmd:identifier>
             <gmd:MD_Identifier>
 				<gmd:code>
-					<gmx:Anchor xlink:href="http://www.my-organisation.eu/so/lu/land-use-map">http://www.my-organisation.eu/so/lu/land-use-map</gmx:Anchor>
+					<gco:CharacterString>http://www.my-organisation.eu/so/lu/land-use-map</gco:CharacterString>
+					<!-- also possible as a gmx:Anchor-Element -->
+					<!-- <gmx:Anchor xlink:href="http://www.my-organisation.eu/so/lu/land-use-map">http://www.my-organisation.eu/so/lu/land-use-map</gmx:Anchor> -->
 				</gmd:code>
             </gmd:MD_Identifier>
           </gmd:identifier>


### PR DESCRIPTION
changed gmd:MD_Identifier for TG Requirement 1.3: metadata/2.0/req/datasets-and-series/dataset-uid: 
from `<gmx:Anchor xlink:href="http://www.my-organisation.eu/so/lu/land-use-map">http://www.my-organisation.eu/so/lu/land-use-map</gmx:Anchor>`

to `
<gco:CharacterString>http://www.my-organisation.eu/so/lu/land-use-map</gco:CharacterString>
					<!-- also possible as a gmx:Anchor-Element -->
					<!-- <gmx:Anchor xlink:href="http://www.my-organisation.eu/so/lu/land-use-map">http://www.my-organisation.eu/so/lu/land-use-map</gmx:Anchor> -->
`