### PR TITLE
Update NetworkService_WMS_metadata_2.0_example

### DIFF
--- a/examples/NetworkService_WMS_metadata_2.0_example
+++ b/examples/NetworkService_WMS_metadata_2.0_example
@@ -47,17 +47,6 @@ The multiplicity of both of these elements is 1.-->
 		<gco:DateTime>2019-05-15T09:00:00</gco:DateTime>
 		<!-- To also specify the time zone (optional), the value would be e.g. 2019-05-15T09:00:00+02:00 -->
 	</gmd:dateStamp>
-	<gmd:referenceSystemInfo>
-		<gmd:MD_ReferenceSystem>
-			<gmd:referenceSystemIdentifier>
-				<gmd:RS_Identifier>
-					<gmd:code>
-						<gmx:Anchor xlink:href="http://www.opengis.net/def/crs/EPSG/0/4258">EPSG:4258</gmx:Anchor>
-					</gmd:code>
-				</gmd:RS_Identifier>
-			</gmd:referenceSystemIdentifier>
-		</gmd:MD_ReferenceSystem>
-	</gmd:referenceSystemInfo>
 	<!--TG Requirement 3.2: metadata/2.0/req/sds/service-identification-element: The first gmd:identificationInfo property of gmd:MD_Metadata element shall contain a srv:SV_ServiceIdentification element for identifying an INSPIRE Spatial Data Service.-->
 	<gmd:identificationInfo>
 		<srv:SV_ServiceIdentification>
@@ -312,14 +301,6 @@ Individual dates and time periods may be combined to form a complex temporal ext
 	</gmd:identificationInfo>
 	<gmd:distributionInfo>
 		<gmd:MD_Distribution>
-			<gmd:distributionFormat>
-				<gmd:MD_Format>
-					<gmd:name>
-						<gmx:Anchor xlink:href="https://www.iana.org/assignments/media-types/image/png">png</gmx:Anchor>
-					</gmd:name>
-					<gmd:version gco:nilReason="http://inspire.ec.europa.eu/codelist/VoidReasonValue/Unknown"/>
-				</gmd:MD_Format>
-			</gmd:distributionFormat>
 			<!--TG Requirement 3.7: metadata/2.0/req/sds/resource-locator
 A Resource locator linking to the described Spatial Data Service shall be given, if online access to this service is available. If no online access to the described Spatial Data Service is available, but there is a publicly available online resource providing additional information about the described service, the URL pointing to this resource shall be given instead. These links shall be encoded using gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/ gmd:CI_OnlineResource/gmd:linkage/gmd:URL element. The multiplicity of this element is 0..n.-->
 			<gmd:transferOptions>


### PR DESCRIPTION
The changes proposed concern two issues: 
1. The metadata element 'CRS Identifier' is not required for the network services, but only for the Interoperable Spatial Data Services;
2. The encoding metadata element (i.e. format name and version) is not required for the services.